### PR TITLE
Change internetCheckUrl to Github

### DIFF
--- a/calamares/modules/welcome_online.conf
+++ b/calamares/modules/welcome_online.conf
@@ -12,7 +12,7 @@ requirements:
     requiredStorage:    5.5
     requiredRam:        1.0
 
-    internetCheckUrl:   https://duckduckgo.com
+    internetCheckUrl:   https://github.com
 
     check:
         - storage


### PR DESCRIPTION
duckduckgo.com can not be connected in China because of "Great Firewall of China", so, that not means user can not connect internet.
Also, I find that, everyone who can go to the internet check step, he mast can connect to Github, because the installer use Github to storage config.